### PR TITLE
kgen_prepost: Fix some bugs in parsing mpif.h

### DIFF
--- a/base/kgen_prepost.py
+++ b/base/kgen_prepost.py
@@ -196,51 +196,25 @@ def preprocess():
                     spec = Specification_Part(reader)
 
                     bag = {}
-                    if Config.mpi['comm'] is None:
-                        bag['key'] = 'MPI_COMM_WORLD'
-                        bag[bag['key']] = []
-                        traverse(spec, get_MPI_PARAM, bag, subnode='content')
-                        if bag.has_key(bag['key']):
-                            Config.mpi['comm'] = bag[bag['key']][-1]
-                        else:
-                            raise UserException('Can not find MPI_COMM_WORLD in mpif.h')
+                    config_name_mapping = [
+                        ('comm', 'MPI_COMM_WORLD'),
+                        ('logical', 'MPI_LOGICAL'),
+                        ('status_size', 'MPI_STATUS_SIZE'),
+                        ('any_source', 'MPI_ANY_SOURCE'),
+                        ('source', 'MPI_SOURCE'),
+                        ]
+                    for config_key, name in config_name_mapping:
+                        if not Config.mpi.has_key(config_key) or Config.mpi[config_key] is None:
+                            bag['key'] = name
+                            bag[name] = []
+                            traverse(spec, get_MPI_PARAM, bag, subnode='content')
+                            if len(bag[name]) > 0:
+                                Config.mpi[config_key] = bag[name][-1]
+                            else:
+                                raise UserException('Can not find {name} in mpif.h'.format(name=name))
 
-                    if Config.mpi['logical'] is None:
-                        bag['key'] = 'MPI_LOGICAL'
-                        bag[bag['key']] = []
-                        traverse(spec, get_MPI_PARAM, bag, subnode='content')
-                        if bag.has_key(bag['key']):
-                            Config.mpi['logical'] = bag[bag['key']][-1]
-                        else:
-                            raise UserException('Can not find MPI_LOGICAL in mpif.h')
-
-                    if Config.mpi['status_size'] is None:
-                        bag['key'] = 'MPI_STATUS_SIZE'
-                        bag[bag['key']] = []
-                        traverse(spec, get_MPI_PARAM, bag, subnode='content')
-                        if bag.has_key(bag['key']):
-                            Config.mpi['status_size'] = bag[bag['key']][-1]
-                        else:
-                            raise UserException('Can not find MPI_STATUS_SIZE in mpif.h')
-
-                    if Config.mpi['any_source'] is None:
-                        bag['key'] = 'MPI_ANY_SOURCE'
-                        bag[bag['key']] = []
-                        traverse(spec, get_MPI_PARAM, bag, subnode='content')
-                        if bag.has_key(bag['key']):
-                            Config.mpi['any_source'] =  bag[bag['key']][-1]
-                        else:
-                            raise UserException('Can not find MPI_ANY_SOURCE in mpif.h')
-
-                    if Config.mpi['source'] is None:
-                        bag['key'] = 'MPI_SOURCE'
-                        bag[bag['key']] = []
-                        traverse(spec, get_MPI_PARAM, bag, subnode='content')
-                        if bag.has_key(bag['key']):
-                            Config.mpi['source'] =  bag[bag['key']][-1]
-                        else:
-                            raise UserException('Can not find MPI_SOURCE in mpif.h')
-
+                except UserException:
+                    raise  # Reraise this exception rather than catching it below
                 except Exception as e:
                     raise UserException('Error occurred during reading %s.'%mpifpath)
             else:

--- a/base/kgen_utils.py
+++ b/base/kgen_utils.py
@@ -184,8 +184,9 @@ def traverse(node, func, bag, subnode='items', prerun=True, depth=0):
         ret = func(node, bag, depth)
         if ret is not None: return ret
 
-    if node and hasattr(node, subnode) and getattr(node, subnode):
-            exec('for child in node.%s: ret = traverse(child, func, bag, subnode=subnode, prerun=prerun, depth=depth+1)' % subnode)
+    if node and hasattr(node, subnode) and getattr(node, subnode) is not None:
+        for child in getattr(node, subnode):
+            ret = traverse(child, func, bag, subnode=subnode, prerun=prerun, depth=depth+1)
 
     if not prerun and func is not None:
         ret = func(node, bag, depth)


### PR DESCRIPTION
**Note**: This does not fix issue-57.  This fixes some issues I found along with issue-57
- raised UserExceptions were getting caught immediately below the
  parsing block.  For this type, make it reraise it unaltered.
- Repetitive code collapsed using a for loop
- Fix the check for the MPI variable found in traverse (because
  bag.has_key(bag['key']) will always return true since it does exist,
  but is an empty list).  Instead check that the list has an item.
- kgen_utils:traverse(): replace exec() command with equivalent code.
  It is easy to do something wrong within an exec() command.
